### PR TITLE
bug: PrevLogIndex of HeartbeatArgs not initialized

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -281,7 +281,7 @@ func (rf *Raft) broadcastHeartbeat() {
 		// 提取 preLogIndex - baseIndex 之后的entry，发送给 follower
 		prevLogIndex := rf.nextIndex[i] - 1
 		if rf.getLastIndex() > prevLogIndex {
-			args.PrevLogTerm = prevLogIndex
+			args.PrevLogIndex = prevLogIndex
 			args.PrevLogTerm = rf.log[prevLogIndex].LogTerm
 			args.Entries = rf.log[prevLogIndex:]
 			log.Printf("send entries: %v\n", args.Entries)


### PR DESCRIPTION
There is a bug present in the code. `args.PrevLogIndex` is not initialised to the correct value, and hence it stays `0`, which causes same log entries to be appended to the Follower's log repeatedly.